### PR TITLE
240923 名字後面加上 discord 的 tag

### DIFF
--- a/script.py
+++ b/script.py
@@ -5,6 +5,21 @@ import os
 from dotenv import load_dotenv
 import subprocess
 
+name_to_id = {
+        # 112
+        "敬淇":"848511725980483594",
+        "晏瑄":"825242239398838322",
+        "昭融":"725632233108406292",
+        "志翔":"732971917891338271",
+        "宥成":"784514869608448070",
+        "子凡":"904797191586070569",
+        # 113
+        "偉銓":"681366003262816267",
+        "育棠":"584774630359826433",
+        "禎圻":"535283333869862932",
+        "松憶":"855824395682840607",
+        "若綾":"867407732084047923"
+    }
 
 def get_row_variable():
     with open('cur_row.conf', 'r') as file:
@@ -31,7 +46,10 @@ def get_cleaner():
     print("sweep:", sweep, "mop:", mop)    
     update_row_variable(row_variable + 1)
     
-    return date, sweep, mop
+    return date, sweep + tag_discord_id(sweep), mop + tag_discord_id(mop)
+
+def tag_discord_id(name):
+    return (dcid := name_to_id.get(name)) and (f"<@{dcid}>" if dcid is not None else "")
 
 if __name__ == "__main__":
     get_cleaner()


### PR DESCRIPTION
有在 name_to_id 的使用者會在需要打掃時一同被 tag，效果如下:

>>> from script import tag_discord_id
>>> tag_discord_id("晏瑄") 
'<@825242239398838322>' #裡面有晏瑄 所以會被tag 例: 掃地+倒垃圾: 晏瑄@fffchameleon(晏瑄) 
>>> tag_discord_id("晏宣") 
>>>                                       #裡面沒有晏宣 所以不會被tag 但也不會跳 error

註: 我名字跟tag中間沒加空白